### PR TITLE
Revert inline function for `sp` in `stack_pointer.h`

### DIFF
--- a/arch/arm64/include/asm/stack_pointer.h
+++ b/arch/arm64/include/asm/stack_pointer.h
@@ -4,14 +4,7 @@
 
 /*
  * How to get the current stack pointer from C
- * Clang does not support global register variable for 'sp'
- * So we define it as an inline function
  */
-static inline unsigned long get_current_sp(void)
-{
-    unsigned long sp;
-    asm volatile("mov %0, sp" : "=r" (sp));
-    return sp;
-}
+register unsigned long current_stack_pointer asm ("sp");
 
 #endif /* __ASM_STACK_POINTER_H */


### PR DESCRIPTION
Revert the inline function for `sp` to avoid compiling error